### PR TITLE
Add fonts to fix the problem that webui cannot display Chinese files …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,10 @@ RUN add-pkg \
         # (e.g. arm64).
         mesa-gl \
         # A font is needed.
-        font-roboto-mono
+        font-roboto-mono \
+        # fonts for Chinese.
+        ttf-dejavu \
+        font-noto-cjk
 
 # Generate and install favicons.
 RUN \


### PR DESCRIPTION
Add fonts to fix the problem that webui cannot display Chinese files or folders when opening files.

Before:
![](https://cdn.baofeidyz.com/img/202412051428824.png)
After:
![](https://cdn.baofeidyz.com/img/202412051432463.png)